### PR TITLE
Fix build issues

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,6 +69,11 @@ jobs:
           rm -fr /__t/* /__host_root/{usr/share/dotnet,usr/local/lib/android,opt/ghc,opt/hostedtoolcache/CodeQL}
           df -h
 
+      - name: Prepare dependencies
+        if: ${{ env.CURRENT_VERSION != env.LAST_BUILT_VERSION || github.event_name == 'workflow_dispatch' }}
+        run: |
+          pacman -U --noconfirm https://archive.archlinux.org/packages/p/python-docutils/python-docutils-1%3A0.21.2-3-any.pkg.tar.zst
+
       - name: Build packages
         if: ${{ env.CURRENT_VERSION != env.LAST_BUILT_VERSION || github.event_name == 'workflow_dispatch' }}
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,10 @@ env:
 jobs:
   main:
     runs-on: ubuntu-latest
-    container: archlinux:latest
+    container:
+      image: archlinux:latest
+      volumes:
+        - /:/__host_root
 
     permissions:
       contents: write
@@ -58,6 +61,13 @@ jobs:
           sudo -u builder gpg-connect-agent reloadagent /bye
 
           chown -R builder .
+
+      - name: Free up space
+        if: ${{ env.CURRENT_VERSION != env.LAST_BUILT_VERSION || github.event_name == 'workflow_dispatch' }}
+        run: |
+          df -h
+          rm -fr /__t/* /__host_root/{usr/share/dotnet,usr/local/lib/android,opt/ghc,opt/hostedtoolcache/CodeQL}
+          df -h
 
       - name: Build packages
         if: ${{ env.CURRENT_VERSION != env.LAST_BUILT_VERSION || github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
Hi,

Thanks for your work! I found two issues and fixed them in this PR.

First, the CI was running out of disk space. I maximized the space by deleting some pre-installed packages, which almost doubles the available space (22GB -> 40GB). I was inspired by [this]([github.com/marketplace/actions/maximize-build-disk-space](https://github.com/marketplace/actions/maximize-build-disk-space)) action and adopted it to work inside a container. It is a bit rough, but gets the job done.

Second, the kernel documentation build was failing due to an incompatibility with python-docutils >= 0.22, the docs flow relies on functions removed in that release. As a workaround the workflow now downloads and installs an older docutils package from the ArchLinux Archive before building the kernel docs.

BR
Antonios